### PR TITLE
Fix self cites

### DIFF
--- a/fixup.js
+++ b/fixup.js
@@ -1,12 +1,13 @@
 require(["core/pubsubhub"], (respecEvents) => {
   respecEvents.sub('end-all', (documentElement) => {
-    // remove data-cite on where the citation is to ourselves.
+    // remove data-cite where the citation is to ourselves.
     const selfCites = Array.from(document.querySelectorAll(`a[data-cite^='${respecConfig.shortName}' i]`));
     for (const anchor of selfCites) {
       const text = anchor.text + ' (this document)';
       const citeParent = anchor.parentNode.parentNode;
-      citeParent.removeChild(anchor.parentNode);
-      citeParent.textContent = text;
+      const textSpan = document.createElement('span');
+      textSpan.textContent = text;
+      citeParent.replaceChild(textSpan, anchor.parentNode);
     }
 
     // Add highlighting and remove comment from pre elements
@@ -27,12 +28,12 @@ function _esc(s) {
     .replace(/</g,'&lt;');
 }
 
-function updateExample(doc, content) {
+function updateExample(utils, content) {
   // perform transformations to make it render and prettier
-  return _esc(unComment(doc, content));
+  return _esc(unComment(utils, content));
 }
 
-function unComment(doc, content) {
+function unComment(utils, content) {
   // perform transformations to make it render and prettier
   return content
     .replace(/<!--/, '')
@@ -40,4 +41,13 @@ function unComment(doc, content) {
     .replace(/< !\s*-\s*-/g, '<!--')
     .replace(/-\s*- >/g, '-->')
     .replace(/-\s*-\s*&gt;/g, '--&gt;');
+}
+
+// If content is a self-citation, replace it with the document name
+function noSelfCite(utils, content) {
+  if (content.toUpperCase() === `[[[${respecConfig.shortName}]]]`.toUpperCase()) {
+    return respecConfig.title + '(this document)';
+  } else {
+    return content;
+  }
 }

--- a/rdf-related.html
+++ b/rdf-related.html
@@ -1,0 +1,16 @@
+<h4>Set of Documents</h4>
+<p>This document is one of ten RDF 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+
+<p>RDF 1.2 Recommendations:</p>
+<ol>
+  <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-N-QUADS]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-N-TRIPLES]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-PRIMER]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-SCHEMA]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-SEMANTICS]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-TRIG]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
+</ol>

--- a/related.html
+++ b/related.html
@@ -3,30 +3,30 @@
 
 <p>RDF 1.2 Recommendations:</p>
 <ol>
-  <li>[[[RDF12-NEW]]]</li>
-  <li>[[[RDF12-CONCEPTS]]]</li>
-  <li>[[[RDF12-N-QUADS]]]</li>
-  <li>[[[RDF12-N-TRIPLES]]]</li>
-  <li>[[[RDF12-PRIMER]]]</li>
-  <li>[[[RDF12-SCHEMA]]]</li>
-  <li>[[[RDF12-SEMANTICS]]]</li>
-  <li>[[[RDF12-TRIG]]]</li>
-  <li>[[[RDF12-TURTLE]]]</li>
-  <li>[[[RDF12-XML]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-N-QUADS]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-N-TRIPLES]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-PRIMER]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-SCHEMA]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-SEMANTICS]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-TRIG]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
 
 <p>SPARQL 1.2 Recommendations:</p>
 <ol>
-  <li>[[[SPARQL12-NEW]]]</li>
-  <li>[[[SPARQL12-CONCEPTS]]]</li>
-  <li>[[[SPARQL12-QUERY]]]</li>
-  <li>[[[SPARQL12-UPDATE]]]</li>
-  <li>[[[SPARQL12-SERVICE-DESCRIPTION]]]</li>
-  <li>[[[SPARQL12-FEDERATED-QUERY]]]</li>
-  <li>[[[SPARQL12-RESULTS-JSON]]]</li>
-  <li>[[[SPARQL12-RESULTS-CSV-TSV]]]</li>
-  <li>[[[SPARQL12-RESULTS-XML]]]</li>
-  <li>[[[SPARQL12-ENTAILMENT]]]</li>
-  <li>[[[SPARQL12-PROTOCOL]]]</li>
-  <li>[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-QUERY]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-UPDATE]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-SERVICE-DESCRIPTION]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-FEDERATED-QUERY]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-RESULTS-JSON]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-RESULTS-CSV-TSV]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-RESULTS-XML]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-ENTAILMENT]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
 </ol>

--- a/sparql-related.html
+++ b/sparql-related.html
@@ -1,0 +1,18 @@
+<h4>Set of Documents</h4>
+<p>This document is one of twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+
+<p>SPARQL 1.2 Recommendations:</p>
+<ol>
+  <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-QUERY]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-UPDATE]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-SERVICE-DESCRIPTION]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-FEDERATED-QUERY]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-RESULTS-JSON]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-RESULTS-CSV-TSV]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-RESULTS-XML]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-ENTAILMENT]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
+  <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
+</ol>


### PR DESCRIPTION
Add `noSelfCite` function and us in `data-transform` on each citation in related.html. This avoids a bibliographic reference being made for the current document, which leads to a ReSpec error.

Add RDF- and SPARQL-specific related references.
