### PR TITLE
Docs in details

### DIFF
--- a/fixup.js
+++ b/fixup.js
@@ -46,7 +46,7 @@ function unComment(utils, content) {
 // If content is a self-citation, replace it with the document name
 function noSelfCite(utils, content) {
   if (content.toUpperCase() === `[[[${respecConfig.shortName}]]]`.toUpperCase()) {
-    return respecConfig.title + '(this document)';
+    return respecConfig.title + ' (this document)';
   } else {
     return content;
   }

--- a/local-biblio.js
+++ b/local-biblio.js
@@ -1,14 +1,4 @@
 var localBibliography = {
-  CBD: {
-    "title": "CBD - Concise Bounded Description",
-    "href": "https://www.w3.org/Submission/CBD/",
-    "authors": [
-      "Patrick Stickler, Nokia"
-    ],
-    "rawDate": "2005-06-03",
-    "publisher": "W3C",
-    "status": "W3C Member Submission"
-  },
   ISO24707: {
     id: "ISO24707",
     title: "Information technology — Common Logic (CL) — A framework for a family of logic-based languages",

--- a/rdf-related.html
+++ b/rdf-related.html
@@ -1,7 +1,9 @@
 <h4>Set of Documents</h4>
-<p>This document is one of ten RDF 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of ten RDF 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
-<p>RDF 1.2 Recommendations:</p>
+<p>RDF 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>
@@ -14,3 +16,4 @@
   <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
+</details>

--- a/related.html
+++ b/related.html
@@ -1,7 +1,9 @@
 <h4>Set of Documents</h4>
-<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
-<p>RDF 1.2 Recommendations:</p>
+<p>RDF 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>
@@ -15,7 +17,7 @@
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
 
-<p>SPARQL 1.2 Recommendations:</p>
+<p>SPARQL 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>
@@ -30,3 +32,4 @@
   <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
 </ol>
+</details>

--- a/sparql-related.html
+++ b/sparql-related.html
@@ -1,7 +1,9 @@
 <h4>Set of Documents</h4>
-<p>This document is one of twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
-<p>SPARQL 1.2 Recommendations:</p>
+<p>SPARQL 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>
@@ -16,3 +18,4 @@
   <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
 </ol>
+</details>


### PR DESCRIPTION
As explored in https://github.com/w3c/sparql-entailment/pull/31:

* Put document references within a details element.
* Reference related "documents" not "recommendations".
* Remove "CBD" from localBiblio, as it's in specRef.
* Add spacing when updating references to "(this document)".
